### PR TITLE
Getting rid of smart quotes in podfiles

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -4,5 +4,5 @@ install! 'cocoapods', :deterministic_uuids => false
 
 target 'DJIVideoPreviewer_Example' do
   pod 'DJIVideoPreviewer', :path => '../'
-  pod 'DJI-SDK-iOS', '~> 4.0’
+  pod 'DJI-SDK-iOS', '~> 4.0'
 end


### PR DESCRIPTION
Cocoapods doesn't recommend to use smart quotes